### PR TITLE
Extension for GwySurface, GwyBrick, GwyGraphModel, GwyGraphCurveModel

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,6 +68,105 @@ It is also possible to manipulate and save objects:
     obj['/0/data'] = GwyDataField(data)
     obj.tofile('noise.gwy')
 
+
+Create a XYZ surface field:
+
+.. code-block:: python
+
+    import numpy as np
+    from gwyfile.objects import GwyContainer, GwyDataField, GwySurface
+    data = np.random.normal(size=(256, 256))  # test data
+    coord0 = np.linspace(0.1, 0.2, data.shape[1])  # test coordinates, in physical space
+    coord1 = np.linspace(0.1, 0.2, data.shape[0])
+
+    # encode data to x,y,z triplets
+    xyz_data = np.array([x for j in range(data.shape[1]) 
+                            for i in range(data.shape[0]) 
+                            for x in (coord0[i], coord1[j], data[j,i])]) 
+
+    # create preview image
+    img = GwyDataField(data=data, si_unit_xy='nm', si_unit_z='nm')
+    img.xoff = coord0[0]
+    img.xreal = coord0[-1] - coord0[0]  # lenth of measured x-coordinate
+    img.yoff = coord1[0]
+    img.yreal = coord1[-1] - coord1[0]  # lenth of measured y-coordinate
+
+    # create surface object
+    xyz = GwySurface(data=xyz_data, si_unit_xy='nm', si_unit_z='nm')
+
+    # create container 
+    obj = GwyContainer()    
+
+    # image object alone 
+    obj['/0/data/title'] = 'Measured height'
+    obj['/0/data'] = img
+
+    # add surface 
+    # (note: 'surface' is the correct field, not 'xyz' as specified by gwyddion.net)
+    obj['/surface/0/title'] = 'Measured height'
+    obj['/surface/0'] = xyz
+    obj['/surface/0/preview'] = img   # preview associated with xyz data
+    obj['/surface/0/visible'] = True
+    obj['/surface/0/meta'] = GwyContainer(data={ 'Start time': '20210105T220000',
+                                                 'End time': '20210105T230500',
+                                                 'Username': 'RexBarker'
+                                                })
+    obj.tofile('MyXYZmeasurement.gwy')
+
+
+
+Create a GraphModel:
+
+.. code-block:: python
+
+    import numpy as np
+    from gwyfile.objects import GwyContainer, GwyGraphModel, GwyGraphCurveModel, GwySIUnit
+
+    # test data
+    xdata = np.array([1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0,10.0])
+    ydata=np.array([1.0,4.0,9.0,16.0,25.0,36.0,49.0,64.0,81.0,100.0])
+    ymeas= ydata + np.random.normal(size=ydata.size)
+
+    # multiple curves are to be created
+    curves = []
+    curve = GwyGraphCurveModel(xdata=xdata, ydata=ydata)
+    curve['description'] = 'Theoretical data'
+
+    # red points for theoretical data
+    curve['color.red'] = 1.0   # color scales 0.0 -> 1.0
+    curve['color.green'] = 0.0
+    curve['color.blue'] = 0.0
+    curve['type'] = 2       # solid line style  (no points)
+    curve['line_style'] = 0 
+    curves.append(curve)
+
+    # a blue line for measured data  
+    curve = GwyGraphCurveModel(xdata=xdata, ydata=ymeas)
+    curve['description'] = 'Measured data'
+    curve['color.red'] = 0.0   # color scales 0.0 -> 1.0
+    curve['color.green'] = 0.0
+    curve['color.blue'] = 1.0
+    curve['type'] = 1       # scatter point style (no line)
+    curve['line_style'] = 0 
+    curves.append(curve)
+
+    # create GraphModel object to hold curves
+    graphobj = GwyGraphModel()
+    graphobj['title'] = "Measurement 1, theory and measurement"
+    graphobj['curves'] = curves
+    graphobj['x_unit'] = GwySIUnit(unitstr='Hz')
+    graphobj['y_unit'] = GwySIUnit(unitstr='c/s')
+    graphobj['bottom_label'] = "TF frequency"
+    graphobj['left_label'] = "Counts per second"
+
+    # add graph model to container
+    obj = GwyContainer()
+    obj['/0/graph/graph/1'] = graphobj
+    obj['/0/graph/graph/1/visible'] = True
+
+    # write out
+    obj.tofile('MyGraphMeasurement.gwy')
+
 The Gwyddion manual has a nice `description of the file format
 <http://gwyddion.net/documentation/user-guide-en/gwyfile-format.html>`_. See
 there for further information on object properties.
@@ -77,8 +176,10 @@ Status
 ------
 
 `GwyObject` serialization and deserialization should be complete. There
-are specialized subclasses for `GwyDataField` and `GwySIUnit`, but other
-convenience wrappers e.g. for `GwyBrick` are missing.
+are specialized subclasses for `GwyDataField` and `GwySIUnit`. Current
+implementation extended with GwySurface, GwyGraphModel, GwyGraphCurveModel.  
+Furthermore, GwyBrick is implemented but not fully tested...no guarantees here.
+Enumeration types were added, but not fully tested.
 
 
 License
@@ -88,3 +189,5 @@ This project is licensed under the MIT license. See `LICENSE.rst <LICENSE.rst>`_
 for details.
 
 © 2014-17 `Tino Wagner <http://www.tinowagner.com/>`_
+
+revision 2021 `RexBarker <https://github.com/RexBarker>`_

--- a/gwyfile/objects.py
+++ b/gwyfile/objects.py
@@ -2,6 +2,9 @@
 
 See <http://gwyddion.net/documentation/user-guide-en/gwyfile-format.html>
 for a specification of Gwyddion native data files.
+
+Revision 14-Jan-2021: added GwySurface 
+Revision 29-Jan-2021: added GwyBrick, GwyGraphModel, GwyGraphCurveModel
 """
 import struct
 from collections import OrderedDict
@@ -9,6 +12,7 @@ import numpy as np
 
 from six import BytesIO, string_types
 from six.moves import range
+from enum import Enum
 
 
 class GwyObject(OrderedDict):
@@ -282,6 +286,642 @@ class GwyDataField(GwyObject):
             self['si_unit_z'] = unit
 
 
+class GwySurface(GwyObject):
+    """GwySurface.
+
+    Parameters
+    ----------
+    data : np.ndarray, shape=(zres, yres, xres)
+        3-dimensional field data.
+    si_unit_xy : GwySIUnit
+        Lateral unit.
+    si_unit_z : GwySIUnit
+        Data value unit.
+    typecodes : dict
+        Dictionary of component typecodes.
+    """
+    def __init__(self, data,
+                 xreal=1.0, yreal=1.0, xoff=0, yoff=0,
+                 si_unit_xy=None, si_unit_z=None,
+                 typecodes=None):
+        super(GwySurface, self).__init__('GwySurface', typecodes=typecodes)
+        if isinstance(data, OrderedDict):
+            self.update(data)
+        else:
+            assert isinstance(data, np.ndarray)
+            self.si_unit_xy, self.si_unit_z = si_unit_xy, si_unit_z
+            self.data = data
+
+    @property
+    def data(self):
+        """Container data."""
+        return self['data']
+
+    @data.setter
+    def data(self, new_data):
+        assert isinstance(new_data, np.ndarray)
+        self['data'] = new_data.flatten()
+
+    @property
+    def si_unit_xy(self):
+        """Unit of lateral dimensions."""
+        return self.get('si_unit_xy', None)
+
+    @si_unit_xy.setter
+    def si_unit_xy(self, unit):
+        if unit is None:
+            if 'si_unit_xy' in self:
+                del self['si_unit_xy']
+        elif isinstance(unit, string_types):
+            self['si_unit_xy'] = GwySIUnit(unitstr=unit)
+        else:
+            self['si_unit_xy'] = unit
+
+    @property
+    def si_unit_z(self):
+        """Unit of data values."""
+        return self.get('si_unit_z', None)
+
+    @si_unit_z.setter
+    def si_unit_z(self, unit):
+        if unit is None:
+            if 'si_unit_z' in self:
+                del self['si_unit_z']
+        elif isinstance(unit, string_types):
+            self['si_unit_z'] = GwySIUnit(unitstr=unit)
+        else:
+            self['si_unit_z'] = unit
+
+
+class GwyBrick(GwyObject):
+    """GwyBrick.
+
+    Parameters
+    ----------
+    data : np.ndarray, shape=(zres, yres, xres)
+        3-dimensional field data.
+    si_unit_ : GwySIUnit
+        Lateral unit.
+    si_unit_y : GwySIUnit
+        Longitudinal unit.
+    si_unit_z : GwySIUnit
+        Data value unit.
+    typecodes : dict
+        Dictionary of component typecodes.
+    """
+    def __init__(self, data,
+                 xres=None, yres=None, zres=None,
+                 xreal=None, yreal=None, zreal=None,
+                 xoff=None, yoff=None, zoff=None,
+                 si_unit_x=None, si_unit_y=None, 
+                 si_unit_z=None, si_unit_w=None,
+                 typecodes=None):
+        super(GwyBrick, self).__init__('GwyBrick', typecodes=typecodes)
+        if isinstance(data, OrderedDict):
+            self.update(data)
+        else:
+            assert isinstance(data, np.ndarray)
+            self.xres, self.yres, self.zres = xres, yres, zres
+            self.xreal, self.yreal, self.zreal = xreal, yreal, zreal 
+            self.xoff, self.yoff, self.zoff = xoff, yoff, zoff 
+            self.si_unit_x = si_unit_x
+            self.si_unit_y = si_unit_y
+            self.si_unit_z = si_unit_z
+            self.si_unit_w = si_unit_w
+            self.data = data
+        self.typecodes.update({
+            'xres': 'i', 'yres': 'i', 'zres': 'i',
+            'xreal': 'd', 'yreal': 'd', 'zreal': 'd',
+            'xoff': 'd', 'yoff': 'd', 'zoff': 'd'
+        })
+
+    @property
+    def data(self):
+        """Container data."""
+        return self['data']
+
+    @data.setter
+    def data(self, new_data):
+        assert isinstance(new_data, np.ndarray)
+        self['data'] = new_data.flatten()
+        
+    @property
+    def xres(self):
+        """Width in physical units."""
+        return self.get('xres', None)
+
+    @xres.setter
+    def xres(self, width):
+        if width is None:
+            if 'xres' in self:
+                del self['xres']
+        else:
+            self['xres'] = width
+            
+    @property
+    def yres(self):
+        """Width in physical units."""
+        return self.get('yres', None)
+
+    @yres.setter
+    def yres(self, width):
+        if width is None:
+            if 'yres' in self:
+                del self['yres']
+        else:
+            self['yres'] = width
+
+    @property
+    def zres(self):
+        """Width in physical units."""
+        return self.get('zres', None)
+
+    @zres.setter
+    def zres(self, width):
+        if width is None:
+            if 'zres' in self:
+                del self['zres']
+        else:
+            self['zres'] = width
+
+    @property
+    def xreal(self):
+        """Width in physical units."""
+        return self.get('xreal', None)
+
+    @xreal.setter
+    def xreal(self, width):
+        if width is None:
+            if 'xreal' in self:
+                del self['xreal']
+        else:
+            self['xreal'] = width
+
+    @property
+    def yreal(self):
+        """Height in physical units."""
+        return self.get('yreal', None)
+
+    @yreal.setter
+    def yreal(self, height):
+        if height is None:
+            if 'yreal' in self:
+                del self['yreal']
+        else:
+            self['yreal'] = height
+
+    @property
+    def zreal(self):
+        """Depth in physical units."""
+        return self.get('zreal', None)
+
+    @zreal.setter
+    def zreal(self, depth):
+        if depth is None:
+            if 'zreal' in self:
+                del self['zreal']
+        else:
+            self['zreal'] = depth 
+
+    @property
+    def xoff(self):
+        """Horizontal offset of top-left corner in physical units."""
+        return self.get('xoff', 0)
+
+    @xoff.setter
+    def xoff(self, offset):
+        self['xoff'] = offset
+
+    @property
+    def yoff(self):
+        """Vertical offset of top-left corner in physical units."""
+        return self.get('yoff', 0)
+
+    @yoff.setter
+    def yoff(self, offset):
+        self['yoff'] = offset
+
+    @property
+    def zoff(self):
+        """Value offset of top-left corner in physical units."""
+        return self.get('zoff', 0)
+
+    @zoff.setter
+    def zoff(self, offset):
+        self['zoff'] = offset
+
+    @property
+    def si_unit_x(self):
+        """Unit of lateral dimensions."""
+        return self.get('si_unit_x', None)
+
+    @si_unit_x.setter
+    def si_unit_x(self, unit):
+        if unit is None:
+            if 'si_unit_x' in self:
+                del self['si_unit_x']
+        elif isinstance(unit, string_types):
+            self['si_unit_x'] = GwySIUnit(unitstr=unit)
+        else:
+            self['si_unit_x'] = unit
+            
+    @property
+    def si_unit_y(self):
+        """Unit of longitudinal dimensions."""
+        return self.get('si_unit_x', None)
+
+    @si_unit_y.setter
+    def si_unit_y(self, unit):
+        if unit is None:
+            if 'si_unit_y' in self:
+                del self['si_unit_y']
+        elif isinstance(unit, string_types):
+            self['si_unit_y'] = GwySIUnit(unitstr=unit)
+        else:
+            self['si_unit_y'] = unit
+
+    @property
+    def si_unit_z(self):
+        """Unit of depth values."""
+        return self.get('si_unit_z', None)
+
+    @si_unit_z.setter
+    def si_unit_z(self, unit):
+        if unit is None:
+            if 'si_unit_z' in self:
+                del self['si_unit_z']
+        elif isinstance(unit, string_types):
+            self['si_unit_z'] = GwySIUnit(unitstr=unit)
+        else:
+            self['si_unit_z'] = unit
+
+    @property
+    def si_unit_w(self):
+        """Unit of measurement values."""
+        return self.get('si_unit_w', None)
+
+    @si_unit_w.setter
+    def si_unit_w(self, unit):
+        if unit is None:
+            if 'si_unit_w' in self:
+                del self['si_unit_w']
+        elif isinstance(unit, string_types):
+            self['si_unit_w'] = GwySIUnit(unitstr=unit)
+        else:
+            self['si_unit_w'] = unit
+
+
+
+class GwyGraphModel(GwyObject):
+    """GwyGraphModel.
+
+    Parameters
+    ----------
+    xdata: np.ndarray, shape(xres)
+        1-D data of Abscissa
+    ydata: np.ndarray, shape(yres)  (note: xres=yres)
+        1-D data of Ordinate 
+    typecodes : dict
+        Dictionary of component typecodes.
+    """
+    def __init__(self,data=None, 
+                 x_min=None, y_min=None, 
+                 x_max=None, y_max=None, 
+                 x_min_set=None, y_min_set=None, 
+                 x_max_set=None, y_max_set=None, 
+                 x_unit=None, y_unit=None,
+                 title=None,
+                 top_label=None, bottom_label=None,
+                 left_label=None, right_label=None,
+                 typecodes=None):
+        super(GwyGraphModel, self).__init__('GwyGraphModel', typecodes=typecodes)
+        self.x_min, self.y_min = x_min, y_min 
+        self.x_max, self.y_max = x_max, y_max 
+        self.x_min_set, self.y_min_set = x_min_set, y_min_set
+        self.x_max_set, self.y_max_set = x_max_set, y_max_set
+        self.x_unit, self.y_unit = x_unit, y_unit 
+        self.typecodes.update({
+            'x_min': 'd', 'y_min': 'd',
+            'x_max': 'd', 'y_max': 'd',
+            'x_min_set': 'b', 'y_min_set': 'b',
+            'x_max_set': 'b', 'y_max_set': 'b',
+            'title': 's',
+            'top_label': 's', 'bottom_label': 's',
+            'left_label': 's', 'right_label': 's',
+            'curves': 'O'
+        })
+
+    @property
+    def x_min(self):
+        return self.get('x_min', None)
+
+    @x_min.setter
+    def x_min(self, value):
+        if value is None:
+            if 'x_min' in self:
+                del self['x_min']
+        else:
+            self['x_min'] = value 
+
+    @property
+    def y_min(self):
+        return self.get('y_min', None)
+
+    @y_min.setter
+    def y_min(self, value):
+        if value is None:
+            if 'y_min' in self:
+                del self['y_min']
+        else:
+            self['y_min'] = value 
+
+    @property
+    def x_max(self):
+        return self.get('x_max', None)
+
+    @x_max.setter
+    def x_max(self, value):
+        if value is None:
+            if 'x_max' in self:
+                del self['x_max']
+        else:
+            self['x_max'] = value 
+
+    @property
+    def y_max(self):
+        return self.get('y_max', None)
+
+    @y_max.setter
+    def y_max(self, value):
+        if value is None:
+            if 'y_max' in self:
+                del self['y_max']
+        else:
+            self['y_max'] = value 
+
+    @property
+    def x_min_set(self):
+        return self.get('x_min_set', False)
+
+    @x_min_set.setter
+    def x_min_set(self, value):
+        if value is None:
+            if 'x_min_set' in self:
+                del self['x_min_set']
+        else:
+            self['x_min_set'] = value 
+            
+    @property
+    def y_min_set(self):
+        return self.get('y_min_set', False)
+
+    @y_min_set.setter
+    def y_min_set(self, value):
+        if value is None:
+            if 'y_min_set' in self:
+                del self['y_min_set']
+        else:
+            self['y_min_set'] = value 
+
+    @property
+    def x_max_set(self):
+        return self.get('x_max_set', False)
+
+    @x_max_set.setter
+    def x_max_set(self, value):
+        if value is None:
+            if 'x_max_set' in self:
+                del self['x_max_set']
+        else:
+            self['x_max_set'] = value 
+            
+    @property
+    def y_max_set(self):
+        return self.get('y_max_set', False)
+
+    @y_max_set.setter
+    def y_max_set(self, value):
+        if value is None:
+            if 'y_max_set' in self:
+                del self['y_max_set']
+        else:
+            self['y_max_set'] = value 
+
+    @property
+    def x_unit(self):
+        """Unit of lateral dimensions."""
+        return self.get('x_unit', None)
+
+    @x_unit.setter
+    def x_unit(self, unit):
+        if unit is None:
+            if 'x_unit' in self:
+                del self['x_unit']
+        elif isinstance(unit, string_types):
+            self['x_unit'] = GwySIUnit(unitstr=unit)
+        else:
+            self['x_unit'] = unit
+
+    @property
+    def y_unit(self):
+        """Unit of data values."""
+        return self.get('y_unit', None)
+
+    @y_unit.setter
+    def y_unit(self, unit):
+        if unit is None:
+            if 'y_unit' in self:
+                del self['y_unit']
+        elif isinstance(unit, string_types):
+            self['y_unit'] = GwySIUnit(unitstr=unit)
+        else:
+            self['y_unit'] = unit
+
+    @property
+    def title(self):
+        """ Graph title"""
+        return self.get('title',None)
+
+    @title.setter
+    def title(self,value):
+        if value is None:
+            if 'title' in self:
+                del self['title']
+        else:
+            self['title'] = value 
+
+    @property
+    def top_label(self):
+        """ Graph top_label"""
+        return self.get('top_label',None)
+
+    @top_label.setter
+    def top_label(self,value):
+        if value is None:
+            if 'top_label' in self:
+                del self['top_label']
+        else:
+            self['top_label'] = value 
+
+    @property
+    def bottom_label(self):
+        """ Graph bottom_label"""
+        return self.get('bottom_label',None)
+
+    @bottom_label.setter
+    def bottom_label(self,value):
+        if value is None:
+            if 'bottom_label' in self:
+                del self['bottom_label']
+        else:
+            self['bottom_label'] = value 
+
+    @property
+    def left_label(self):
+        """ Graph left_label"""
+        return self.get('left_label',None)
+
+    @left_label.setter
+    def left_label(self,value):
+        if value is None:
+            if 'left_label' in self:
+                del self['left_label']
+        else:
+            self['left_label'] = value 
+
+    @property
+    def right_label(self):
+        """ Graph right_label"""
+        return self.get('right_label',None)
+
+    @right_label.setter
+    def right_label(self,value):
+        if value is None:
+            if 'right_label' in self:
+                del self['right_label']
+        else:
+            self['right_label'] = value 
+
+
+class GwyGraphCurveModel(GwyObject):
+    """GwyGraphCurveModel.
+
+    Parameters
+    ----------
+    xdata : np.ndarray, shape=(xres)
+        1-dimensional field data.
+    ydata : np.ndarray, shape=(yres) (yres=xres)
+        1-dimensional field data.
+    description : string
+        Description of curve 
+    type : int
+        Curve mode (points, lines, etc), from GwyGraphCurveType enum
+    point_type : int
+        point type from GwyGraphPointType enum
+    line_type : int
+        point type from GwyGraphLineType enum
+    line_size : int
+        width of lines  
+    typecodes : dict
+        Dictionary of component typecodes.
+    """
+    def __init__(self, data=None,
+                 xdata=None, ydata=None, type=None, 
+                 point_type=None,  point_size=None, line_type=None, line_size=None,
+                 color_red=None, color_green=None, color_blue=None,
+                 typecodes=None):
+        super(GwyGraphCurveModel, self).__init__('GwyGraphCurveModel', typecodes=typecodes)
+        if isinstance(data, dict):
+            self.update(data)
+
+        if xdata is not None:
+            assert isinstance(xdata, np.ndarray) and len(xdata.shape) == 1
+            self.xdata = xdata
+
+        if ydata is not None:
+            assert isinstance(ydata, np.ndarray) and len(ydata.shape) == 1
+            self.ydata = ydata
+
+        self.point_type, self.point_size = point_type, point_size 
+        self.line_type, self.line_size = line_type, line_size 
+        self.typecodes.update({
+            'point_type': 'i', 'point_size': 'i',
+            'line_type': 'i', 'line_size': 'i'
+        })
+
+    @property
+    def xdata(self):
+        """Container data."""
+        return self['xdata']
+
+    @xdata.setter
+    def xdata(self, new_data):
+        assert isinstance(new_data, np.ndarray)
+        self['xdata'] = new_data.flatten()
+
+    @property
+    def ydata(self):
+        """Container data."""
+        return self['ydata']
+
+    @ydata.setter
+    def ydata(self, new_data):
+        assert isinstance(new_data, np.ndarray)
+        self['ydata'] = new_data.flatten()
+
+    @property
+    def point_type(self):
+        return self['point_type']
+
+    @point_type.setter
+    def point_type(self,ptype):
+        if ptype is None:
+            if 'point_type' in self:
+                del self['point_type']
+        elif isinstance(ptype, GwyGraphPointType):
+            self['point_type'] = ptype.value
+        else:
+            self['point_type'] = ptype 
+
+    @property
+    def point_size(self):
+        return self['point_size']
+
+    @point_size.setter
+    def point_size(self,psize):
+        if psize is None:
+            if 'point_size' in self:
+                del self['point_size']
+        else:
+            self['point_size'] = psize 
+
+    @property
+    def line_type(self):
+        return self['line_type']
+
+    @line_type.setter
+    def line_type(self,ltype):
+        if ltype is None:
+            if 'line_type' in self:
+                del self['line_type']
+        elif isinstance(ltype, GwyGraphLineType):
+            self['line_type'] = ltype.value
+        else:
+            self['line_type'] = ltype 
+
+    @property
+    def line_size(self):
+        return self['line_size']
+
+    @line_size.setter
+    def line_size(self,lsize):
+        if lsize is None:
+            if 'line_size' in self:
+                del self['line_size']
+        else:
+            self['line_size'] = lsize 
+
+
 class GwySIUnit(GwyObject):
     def __init__(self, data=None, unitstr='', typecodes=None):
         super(GwySIUnit, self).__init__('GwySIUnit', typecodes=typecodes)
@@ -298,6 +938,73 @@ class GwySIUnit(GwyObject):
     @unitstr.setter
     def unitstr(self, s):
         self['unitstr'] = s
+
+class GwyGraphPointType(Enum):
+    """GwyGraphPointType enumerations
+        according to documentation: 
+         - http://gwyddion.net/documentation/libgwydgets/libgwydgets-gwydgetenums.php
+        additional references from:
+         - https://sourceforge.net/p/gwyddion/code/HEAD/tarball?path=/trunk/gwyddiono
+         - trunk/libgwydgets/gwydgetenums.h
+    """
+    GWY_GRAPH_POINT_SQUARE                = 0
+    GWY_GRAPH_POINT_CROSS                 = 1
+    GWY_GRAPH_POINT_CIRCLE                = 2
+    GWY_GRAPH_POINT_STAR                  = 3
+    GWY_GRAPH_POINT_TIMES                 = 4
+    GWY_GRAPH_POINT_TRIANGLE_UP           = 5
+    GWY_GRAPH_POINT_TRIANGLE_DOWN         = 6
+    GWY_GRAPH_POINT_DIAMOND               = 7
+    GWY_GRAPH_POINT_FILLED_SQUARE         = 8
+    GWY_GRAPH_POINT_DISC                  = 9
+    GWY_GRAPH_POINT_FILLED_CIRCLE         = GWY_GRAPH_POINT_DISC
+    GWY_GRAPH_POINT_FILLED_TRIANGLE_UP    = 10
+    GWY_GRAPH_POINT_FILLED_TRIANGLE_DOWN  = 11
+    GWY_GRAPH_POINT_FILLED_DIAMOND        = 12
+    GWY_GRAPH_POINT_TRIANGLE_LEFT         = 13
+    GWY_GRAPH_POINT_FILLED_TRIANGLE_LEFT  = 14
+    GWY_GRAPH_POINT_TRIANGLE_RIGHT        = 15
+    GWY_GRAPH_POINT_FILLED_TRIANGLE_RIGHT = 16
+    GWY_GRAPH_POINT_ASTERISK              = 17
+
+class GwyGraphLineType(Enum):
+    """GwyGraphLineType enumerations
+        not actually defined in documentation: 
+         - http://gwyddion.net/documentation/libgwydgets/libgwydgets-gwydgetenums.php
+        or in the repo
+         - https://sourceforge.net/p/gwyddion/code/HEAD/tarball?path=/trunk/gwyddiono
+        so this is back-extrapolated by experiment, could have other values
+    """
+    GWY_LINE_TYPE_HIDDEN = 0 
+    GWY_LINE_TYPE_POINTS = 1
+    GWY_LINE_TYPE_LINE = 2
+
+
+class GwyGraphCurveType(Enum):
+    """GwyCurveType enumerations
+        according to documentation: 
+         - http://gwyddion.net/documentation/libgwydgets/libgwydgets-gwydgetenums.php
+        additional references from:
+         - https://sourceforge.net/p/gwyddion/code/HEAD/tarball?path=/trunk/gwyddiono
+         - trunk/libgwydgets/gwydgetenums.h
+    """
+    GWY_GRAPH_CURVE_HIDDEN      = 0
+    GWY_GRAPH_CURVE_POINTS      = 1
+    GWY_GRAPH_CURVE_LINE        = 2
+    GWY_GRAPH_CURVE_LINE_POINTS = 3
+
+
+class GwyCurveType(Enum):
+    """GwyCurveType enumerations
+        according to documentation: 
+         - http://gwyddion.net/documentation/libgwydgets/libgwydgets-gwydgetenums.php
+        additional references from:
+         - https://sourceforge.net/p/gwyddion/code/HEAD/tarball?path=/trunk/gwyddiono
+         - trunk/libgwydgets/gwydgetenums.h
+    """
+    GWY_CURVE_TYPE_LINEAR = 0 
+    GWY_CURVE_TYPE_SPLINE = 1
+    GWY_CURVE_TYPE_FREE = 2
 
 
 def component_from_buffer(buf, return_size=False):
@@ -328,7 +1035,7 @@ def component_from_buffer(buf, return_size=False):
         data = ord(buf[pos:pos+1]) != 0
         endpos += 1
     elif typecode == 'c':
-        data = buf[pos]
+        data = struct.unpack('<c',buf[pos:pos+1])[0].decode('utf-8')
         endpos += 1
     elif typecode == 'i':
         data = struct.unpack('<i', buf[endpos:endpos + 4])[0]
@@ -407,6 +1114,8 @@ def guess_typecode(value):
             return 'C'
         else:
             raise NotImplementedError
+    elif type(value) is list:
+        return 'O'
     else:
         raise NotImplementedError('{}, type: {}'.format(value,
                                                         type(value)))
@@ -468,5 +1177,9 @@ def serialize_component(name, value, typecode=None):
 _gwyddion_types = {
     'GwyContainer': GwyContainer,
     'GwyDataField': GwyDataField,
+    'GwySurface': GwySurface,
+    'GwyBrick': GwyBrick,
+    'GwyGraphModel': GwyGraphModel,
+    'GwyGraphCurveModel': GwyGraphCurveModel,
     'GwySIUnit': GwySIUnit,
 }


### PR DESCRIPTION
Extended basic gwy.objects definition to include GwySurface, GwyBrick, GwyGraphModel, and GwyGraphCurveModel classes.  Examples of usage updated in the README.rst file.  This was tested on GwySurface and GwyGraphModel/CurveModel objects and seems to work fine.  I did not fully test on GwyBrick datatypes as I did not have any good example data for my use case.  The various Enum types were implemented from the documentation, but may not be complete.  Also, these were not tested fully