### PR TITLE
Support read/write from pathlib.Path on Py3.6+.

### DIFF
--- a/gwyfile/objects.py
+++ b/gwyfile/objects.py
@@ -100,6 +100,8 @@ class GwyObject(OrderedDict):
         file : file or str
             File object or filename.
         """
+        if hasattr(type(file), '__fspath__'):
+            file = type(file).__fspath__(file)
         if isinstance(file, string_types):
             with open(file, 'rb') as f:
                 return GwyObject._read_file(f)
@@ -113,6 +115,8 @@ class GwyObject(OrderedDict):
         file : file or str
             File object or filename.
         """
+        if hasattr(type(file), '__fspath__'):
+            file = type(file).__fspath__(file)
         if isinstance(file, string_types):
             with open(file, 'wb') as f:
                 self._write_file(f)


### PR DESCRIPTION
Note that the way `__fspath__` is being invoked is basically the
definition mandated by PEP519, without having to separately define
os.fspath, which means that older versions of Python should also work if
using a pathlib backport.