### PR TITLE
Function change to deal with NumPy deprecation

### DIFF
--- a/gwyfile/objects.py
+++ b/gwyfile/objects.py
@@ -348,7 +348,7 @@ def component_from_buffer(buf, return_size=False):
         }
         dtype = typelookup[typecode]
         pos, endpos = endpos, endpos + dtype.itemsize * numitems
-        data = np.fromstring(buf[pos:endpos], dtype=dtype)
+        data = np.frombuffer(buf[pos:endpos], dtype=dtype)
     elif typecode == 'S':
         numitems = struct.unpack('<I', buf[pos:pos + 4])[0]
         endpos += 4

--- a/tests/test_gwyobject.py
+++ b/tests/test_gwyobject.py
@@ -19,6 +19,8 @@ def test_datafield(test_data):
     test_channel = channels['Test']
     data = test_channel.data
     assert data.shape == (128, 128)
+    assert data[0][0] == pytest.approx(0.00082494, 1E-5)
+    assert data[44][33] == pytest.approx(0.00085301, 1E-5)
 
 
 def test_tofile(test_data, tmpdir):


### PR DESCRIPTION
I changed `np.fromstring` to `np.frombuffer` because of a NumPy [deprecation](https://numpy.org/doc/stable/reference/generated/numpy.fromstring.html) warning. 

This was likely triggered because `type(buf) = <class 'bytes'>` and `np.fromstring` doesn't accept `sep=''` anymore.

I also added some testing on the actual data values.